### PR TITLE
GitHub Action to automatically create backport PRs

### DIFF
--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -1,0 +1,30 @@
+on:
+  pull_request_target:
+    types: ["labeled", "closed"]
+
+jobs:
+  backport:
+    name: Backport PR
+    runs-on: ubuntu-latest
+    if: |
+      github.event.pull_request.merged == true
+      && contains(github.event.pull_request.labels.*.name, 'Needs Backport')
+      && (
+        (github.event.action == 'labeled' && github.event.label.name == 'Needs Backport')
+        || (github.event.action == 'closed')
+      )
+    steps:
+      - name: Backport Action
+        uses: sqren/backport-github-action@v8.9.3
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          auto_backport_label_prefix: Needs Backport-
+          add_original_reviewers: true
+
+      - name: Info log
+        if: ${{ success() }}
+        run: cat ~/.backport/backport.info.log
+
+      - name: Debug log
+        if: ${{ failure() }}
+        run: cat ~/.backport/backport.debug.log


### PR DESCRIPTION
This commit integrates the backport-github-action [1] GitHub Action.

It automatically creates PRs for the branches specified via labels on another PR. For instance, if a PR to master has the following labels:

- Needs Backport
- Needs Backport-v3.2
- Needs Backport-v3.1

It'll create two other PRs, cherry-picking the commits on v3.2 and v3.1 branches. The action is triggered whenever:

- A PR with those labels is merged
- A closed PR has those labels added

After the action runs, the "parent" PR is updated with a status report, informing of any encountered error (e.g., merge conflicts).

We've chosen this action over the Backporting [2] action because the former has support for PRs containing multiple commits, which corresponds to our current flow. At the same time, the latter only works with single-commit PRs.

1 - https://github.com/sqren/backport-github-action 2 - https://github.com/marketplace/actions/backporting

## Summary

<!--
  Please include a summary of your changes, along with any useful context.

  You're encouraged to include screenshots in case of visual changes.

  If needed, you can reference other PRs or issues here with #ISSUE-NUMBER.
-->

## Checklist

Check out our [PR guidelines](https://github.com/solidusio/solidus/blob/master/CONTRIBUTING.md#pull-request-guidelines) for more details.

The following are mandatory for all PRs:

- [ ] I have written a thorough PR description.
- [ ] I have kept my commits small and atomic.
- [ ] I have used clear, explanatory commit messages.

The following are not always needed (~cross them out~ if they are not):

- [ ] I have added automated tests to cover my changes.
- [ ] I have attached screenshots to demo visual changes.
- [ ] I have opened a PR to update the [guides](https://github.com/solidusio/edgeguides).
- [ ] I have updated the readme to account for my changes.
